### PR TITLE
Skip validation if schema is invalid

### DIFF
--- a/apps/client/dashboard/src/hooks/use-database.test.ts
+++ b/apps/client/dashboard/src/hooks/use-database.test.ts
@@ -1,0 +1,11 @@
+import { renderHook } from "@testing-library/react";
+import { describe, test, expect } from "vitest";
+import { useDatabase } from "./use-database";
+
+describe("useDatabase", () => {
+  test("should throw an error if used outside of DatabaseProvider", () => {
+    expect(() => renderHook(() => useDatabase())).toThrowError(
+      "useDatabase must be used within a DatabaseProvider",
+    );
+  });
+});

--- a/apps/client/dashboard/src/hooks/use-profile.test.ts
+++ b/apps/client/dashboard/src/hooks/use-profile.test.ts
@@ -1,0 +1,11 @@
+import { renderHook } from "@testing-library/react";
+import { describe, test, expect } from "vitest";
+import { useProfile } from "./use-profile";
+
+describe("useProfile", () => {
+  test("should throw an error if used outside of ProfileProvider", () => {
+    expect(() => renderHook(() => useProfile())).toThrowError(
+      "useProfile must be used within a ProfileProvider",
+    );
+  });
+});

--- a/apps/client/dashboard/src/hooks/use-settings.test.ts
+++ b/apps/client/dashboard/src/hooks/use-settings.test.ts
@@ -1,0 +1,11 @@
+import { renderHook } from "@testing-library/react";
+import { describe, test, expect } from "vitest";
+import { useSettings } from "./use-settings";
+
+describe("useSettings", () => {
+  test("should throw an error if used outside of SettingsProvider", () => {
+    expect(() => renderHook(() => useSettings())).toThrowError(
+      "useSettings must be used within a SettingsProvider",
+    );
+  });
+});

--- a/apps/client/dashboard/src/utils/data.test.ts
+++ b/apps/client/dashboard/src/utils/data.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "vitest";
-import { generateTestProfile } from "./data";
+import { generateTestProfile, getDataValidationErrors } from "./data";
+import { type Data } from "@monyfox/common-data";
 
 describe("generateTestProfile", () => {
   test("generate a profile with the correct structure", () => {
@@ -11,6 +12,64 @@ describe("generateTestProfile", () => {
 
     expect(profile.data.data.accounts.length).toBeGreaterThan(0);
     expect(profile.data.data.transactions.length).toBeGreaterThan(0);
+    expect(profile.data.data.transactionCategories.length).toBeGreaterThan(0);
     expect(profile.data.data.assetSymbols.length).toBeGreaterThan(0);
+  });
+});
+
+describe("getDataValidationErrors", () => {
+  test("should return an error for cycles in transaction categories", () => {
+    const data: Data = {
+      accounts: [],
+      transactions: [],
+      transactionCategories: [
+        { id: "1", name: "Category 1", parentTransactionCategoryId: "2" },
+        { id: "2", name: "Category 2", parentTransactionCategoryId: "1" },
+      ],
+      assetSymbols: [],
+      assetSymbolExchanges: [],
+      assetSymbolExchangersMetadata: { alphavantage: null },
+      lastUpdated: new Date().toISOString(),
+    };
+
+    const errors = getDataValidationErrors(data);
+    expect(errors).toContain("There are cycles in the transaction categories");
+  });
+
+  test("should return an error for non-existing parent category", () => {
+    const data: Data = {
+      accounts: [],
+      transactions: [],
+      transactionCategories: [
+        { id: "1", name: "Category 1", parentTransactionCategoryId: "2" },
+      ],
+      assetSymbols: [],
+      assetSymbolExchanges: [],
+      assetSymbolExchangersMetadata: { alphavantage: null },
+      lastUpdated: new Date().toISOString(),
+    };
+
+    const errors = getDataValidationErrors(data);
+    expect(errors).toContain(
+      "Transaction category Category 1 has a non-existing parent category",
+    );
+  });
+
+  test("should return no errors for valid data", () => {
+    const data: Data = {
+      accounts: [],
+      transactions: [],
+      transactionCategories: [
+        { id: "1", name: "Category 1", parentTransactionCategoryId: null },
+        { id: "2", name: "Category 2", parentTransactionCategoryId: "1" },
+      ],
+      assetSymbols: [],
+      assetSymbolExchanges: [],
+      assetSymbolExchangersMetadata: { alphavantage: null },
+      lastUpdated: new Date().toISOString(),
+    };
+
+    const errors = getDataValidationErrors(data);
+    expect(errors).toHaveLength(0);
   });
 });

--- a/apps/client/dashboard/src/utils/tests/contexts.tsx
+++ b/apps/client/dashboard/src/utils/tests/contexts.tsx
@@ -2,7 +2,7 @@ import { SidebarProvider } from "@/components/ui/sidebar";
 import { AssetSymbolExchangeRateProvider } from "@/contexts/asset-symbol-exchange-rate-provider";
 import { ProfileProvider } from "@/contexts/profile-provider";
 import { SettingsProvider } from "@/contexts/settings-provider";
-import { type Profile } from "@monyfox/common-data";
+import { type TransactionCategory, type Profile } from "@monyfox/common-data";
 import {
   QueryClient,
   QueryClientProvider,
@@ -16,10 +16,16 @@ import { type ExchangeRateDb } from "@/database/database";
 
 export function TestDatabaseProvider({
   children,
+  withEncryptedData = false,
+  withInvalidSchema = false,
+  withInvalidData = false,
   withFiat = true,
   withStocks = true,
 }: {
   children: ReactNode;
+  withEncryptedData?: boolean;
+  withInvalidSchema?: boolean;
+  withInvalidData?: boolean;
   withFiat?: boolean;
   withStocks?: boolean;
 }) {
@@ -27,104 +33,114 @@ export function TestDatabaseProvider({
     {
       id: "TEST_PROFILE_ID",
       user: "TEST_USER",
-      data: {
-        encrypted: false,
-        data: {
-          accounts: [
-            {
-              id: "ACCOUNT_1",
-              name: "Account 1",
-              isPersonalAsset: true,
+      data: withEncryptedData
+        ? {
+            encrypted: true,
+            data: "ENCRYPTED_DATA",
+          }
+        : {
+            encrypted: false,
+            data: {
+              accounts: [
+                {
+                  id: "ACCOUNT_1",
+                  name: "Account 1",
+                  isPersonalAsset: true,
+                },
+                {
+                  id: "ACCOUNT_2",
+                  name: "Account 2",
+                  isPersonalAsset: true,
+                },
+              ],
+              assetSymbols: [
+                ...(withFiat
+                  ? [
+                      {
+                        id: "EUR",
+                        code: "EUR",
+                        displayName: "EUR",
+                        type: "fiat" as const,
+                      },
+                      {
+                        id: "USD",
+                        code: "USD",
+                        displayName: "USD",
+                        type: "fiat" as const,
+                      },
+                    ]
+                  : []),
+                ...(withStocks
+                  ? [
+                      {
+                        id: "MWRD",
+                        code: "MWRD",
+                        displayName: "MWRD ETF name",
+                        type: "stock" as const,
+                      },
+                    ]
+                  : []),
+              ],
+              assetSymbolExchanges: [],
+              assetSymbolExchangersMetadata: {
+                alphavantage: withStocks ? { apiKey: "TEST_API_KEY" } : null,
+              },
+              transactions: [
+                {
+                  id: "TRANSACTION_1",
+                  description: "Income",
+                  transactionDate: "2024-01-01",
+                  accountingDate: "2024-01-01",
+                  transactionCategoryId: "CATEGORY_1",
+                  from: {
+                    account: { name: "Income" },
+                    amount: 950,
+                    symbolId: "EUR",
+                  },
+                  to: {
+                    account: { id: "ACCOUNT_1" },
+                    amount: 950,
+                    symbolId: "EUR",
+                  },
+                },
+                {
+                  id: "TRANSACTION_1",
+                  description: "Expense",
+                  transactionDate: "2024-01-01",
+                  accountingDate: "2024-01-01",
+                  transactionCategoryId: null,
+                  from: {
+                    account: { id: "ACCOUNT_1" },
+                    amount: 23,
+                    symbolId: "EUR",
+                  },
+                  to: {
+                    account: { name: "Expense" },
+                    amount: 23,
+                    symbolId: "EUR",
+                  },
+                },
+              ],
+              transactionCategories: withInvalidSchema
+                ? // @ts-expect-error - Invalid schema
+                  (null as TransactionCategory[])
+                : [
+                    {
+                      id: "CATEGORY_1",
+                      name: "Category 1",
+                      parentTransactionCategoryId: withInvalidData
+                        ? "CATEGORY_1_1" // Cyclic dependency for invalid data
+                        : null,
+                    },
+                    {
+                      id: "CATEGORY_1_1",
+                      name: "Subcategory 1-1",
+                      parentTransactionCategoryId: "CATEGORY_1",
+                    },
+                  ],
+              lastUpdated: "2024-01-01T00:00:00.000Z",
             },
-            {
-              id: "ACCOUNT_2",
-              name: "Account 2",
-              isPersonalAsset: true,
-            },
-          ],
-          assetSymbols: [
-            ...(withFiat
-              ? [
-                  {
-                    id: "EUR",
-                    code: "EUR",
-                    displayName: "EUR",
-                    type: "fiat" as const,
-                  },
-                  {
-                    id: "USD",
-                    code: "USD",
-                    displayName: "USD",
-                    type: "fiat" as const,
-                  },
-                ]
-              : []),
-            ...(withStocks
-              ? [
-                  {
-                    id: "MWRD",
-                    code: "MWRD",
-                    displayName: "MWRD ETF name",
-                    type: "stock" as const,
-                  },
-                ]
-              : []),
-          ],
-          assetSymbolExchanges: [],
-          assetSymbolExchangersMetadata: {
-            alphavantage: withStocks ? { apiKey: "TEST_API_KEY" } : null,
           },
-          transactions: [
-            {
-              id: "TRANSACTION_1",
-              description: "Income",
-              transactionDate: "2024-01-01",
-              accountingDate: "2024-01-01",
-              transactionCategoryId: "CATEGORY_1",
-              from: {
-                account: { name: "Income" },
-                amount: 950,
-                symbolId: "EUR",
-              },
-              to: {
-                account: { id: "ACCOUNT_1" },
-                amount: 950,
-                symbolId: "EUR",
-              },
-            },
-            {
-              id: "TRANSACTION_1",
-              description: "Expense",
-              transactionDate: "2024-01-01",
-              accountingDate: "2024-01-01",
-              transactionCategoryId: null,
-              from: {
-                account: { id: "ACCOUNT_1" },
-                amount: 23,
-                symbolId: "EUR",
-              },
-              to: {
-                account: { name: "Expense" },
-                amount: 23,
-                symbolId: "EUR",
-              },
-            },
-          ],
-          transactionCategories: [
-            {
-              id: "CATEGORY_1",
-              name: "Category 1",
-              parentTransactionCategoryId: null,
-            },
-            {
-              id: "CATEGORY_1_1",
-              name: "Subcategory 1-1",
-              parentTransactionCategoryId: "CATEGORY_1",
-            },
-          ],
-          lastUpdated: "2024-01-01T00:00:00.000Z",
-        },
-      },
       schemaVersion: "1",
     },
   ]);
@@ -185,17 +201,29 @@ export function TestQueryClientProvider({ children }: { children: ReactNode }) {
 export function TestContextProvider({
   children,
   profileId = "TEST_PROFILE_ID",
+  withEncryptedData = false,
+  withInvalidSchema = false,
+  withInvalidData = false,
   withFiat = true,
   withStocks = true,
 }: {
   children: ReactNode;
   profileId?: string;
+  withEncryptedData?: boolean;
+  withInvalidSchema?: boolean;
+  withInvalidData?: boolean;
   withFiat?: boolean;
   withStocks?: boolean;
 }) {
   const router = getTestRouter(() => (
     <TestQueryClientProvider>
-      <TestDatabaseProvider withFiat={withFiat} withStocks={withStocks}>
+      <TestDatabaseProvider
+        withEncryptedData={withEncryptedData}
+        withInvalidSchema={withInvalidSchema}
+        withInvalidData={withInvalidData}
+        withFiat={withFiat}
+        withStocks={withStocks}
+      >
         <ProfileProvider profileId={profileId}>
           <AssetSymbolExchangeRateProvider>
             <SettingsProvider>


### PR DESCRIPTION
* Skip data validation when the schema is invalid as it might result in runtime errors (e.g., trying to iterate over undefined arrays).
* Add tests.